### PR TITLE
reload模块及entity模块优化

### DIFF
--- a/pkg/common/dsync/dto.go
+++ b/pkg/common/dsync/dto.go
@@ -18,7 +18,8 @@ type SyncOption struct {
 	SyncToEs          bool `json:"sync_to_es,omitempty"`
 	Upsert            bool `json:"upsert,omitempty"` // db2es/es2db 时, 是否采用 upsert 方式。如果为 true，那么会先根据 id 进行查询，如果存在就更新，不存在就插入。如果为 false，那么会先根据 id 进行查询，如果存在就跳过，不存在就插入。
 
-	StartId string `json:"start_id,omitempty"` // 从哪个 id 开始，升序
+	//StartId  string `json:"start_id,omitempty"` // 从哪个 id 开始，升序
+	StartEid int64 `json:"start_eid,omitempty"`
 
 	// 同步的时候，用于存储一些临时数据
 	TempData any `json:"-"`

--- a/pkg/core/entity/entity.go
+++ b/pkg/core/entity/entity.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	IdDbName              = "id"
+	EIdDbName             = "eid"
 	CreatedAtDbName       = "created_at"
 	UpdatedAtDbName       = "updated_at"
 	CreatorIdDbName       = "creator_id"
@@ -26,6 +27,7 @@ const (
 	RankDbName            = "rank"
 
 	IdFieldName              = "ID"
+	EIdFieldName             = "EID"
 	CreatedAtFieldName       = "CreatedAt"
 	UpdatedAtFieldName       = "UpdatedAt"
 	CreatorIdFieldName       = "CreatorId"
@@ -63,6 +65,7 @@ type MetaInfo struct {
 // BaseEntity TODO 可以定义接口，然后来处理CreateUser、UpdateUser等
 type BaseEntity struct {
 	ID              string             `json:"id,omitempty" gorm:"type:varchar(255);column:id;<-:create;comment:ID" redis:"id"  binding:"required" es:"type:keyword"`
+	EID             int64              `json:"eid,omitempty" gorm:"column:eid;autoIncrement:true;comment:实体唯一标识,非全局唯一;" es:"type:long"`
 	CreatedAt       *ctype.LocalTime   `json:"created_at,omitempty" gorm:"<-:create;comment:创建时间;not null" redis:"created_at"  binding:"ignore" es:"type:date"`
 	UpdatedAt       int64              `json:"updated_at,omitempty" gorm:"autoUpdateTime:milli;comment:更新时间戳;not null"  redis:"updated_at"  binding:"required" es:"type:long"`
 	CreatorId       string             `json:"creator_id,omitempty" gorm:"type:varchar(255);column:creator_id;<-:create;comment:创建人;not null"  redis:"creator_id" es:"type:keyword"`
@@ -96,7 +99,7 @@ func (b BaseEntity) DefaultColumns() []string {
 	return []string{"*"}
 }
 func (b BaseEntity) MustColumns() []string {
-	return []string{IdDbName, UpdatedAtDbName}
+	return []string{IdDbName, EIdDbName, UpdatedAtDbName}
 }
 func (b BaseEntity) EmbeddedPrefix() string {
 	return "emb_"
@@ -118,5 +121,5 @@ func (b BaseEdgeEntity) DefaultColumns() []string {
 	return []string{"*"}
 }
 func (b BaseEdgeEntity) MustColumns() []string {
-	return []string{IdDbName, UpdatedAtDbName, FromIdDbName, ToIdDbName}
+	return []string{IdDbName, EIdDbName, UpdatedAtDbName, FromIdDbName, ToIdDbName}
 }

--- a/pkg/core/service/service_update.go
+++ b/pkg/core/service/service_update.go
@@ -220,15 +220,15 @@ func GetUpdateColumn(obj any, mustCols ...string) []string {
 		return []string{}
 	}
 	var (
-		gormFieldMap = entity.GetGormFieldName(obj)
-		cols         = append([]string{}, mustCols...)
-		val          = reflect.ValueOf(obj)
+		dbCols = entity.GetTableColumns(obj)
+		cols   = append([]string{}, mustCols...)
+		val    = reflect.ValueOf(obj)
 	)
 	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
-	for k, v := range gormFieldMap {
-		fieldVal := val.FieldByName(k)
+	for _, v := range dbCols {
+		fieldVal := val.FieldByName(v)
 		if fieldVal.IsValid() && !fieldVal.IsZero() {
 			cols = append(cols, v)
 		}

--- a/pkg/core/service/sqlbd_stats.go
+++ b/pkg/core/service/sqlbd_stats.go
@@ -20,7 +20,7 @@ func AggregateSql(cfg *hook.SrvConfig) (*sqlbd.SqlList, error) {
 		aggBd  = builder.NewAggregateSqlBuilder(dbType, scm, tbName).SetCteName("r")
 	)
 
-	filterBd := buildIdListSqlBuilder(cfg)
+	filterBd := buildIdListSqlBuilder(cfg.GetDB(), cfg.Param, cfg.GetEntityConfig())
 	if filterBd != nil {
 		aggBd.With("ids", filterBd)
 		aggBd.Join("", "ids", entity.IdDbName, tbName, entity.IdDbName)
@@ -103,7 +103,7 @@ func PartitionSql(cfg *hook.SrvConfig) (*sqlbd.SqlList, error) {
 	cte.AddExprColumn(cfg.Param.ExtraColumns...)
 	cte.AddPartitionColumn(cfg.Param.PartitionColumns...)
 
-	filterBd := buildIdListSqlBuilder(cfg)
+	filterBd := buildIdListSqlBuilder(cfg.GetDB(), cfg.Param, cfg.GetEntityConfig())
 	if filterBd != nil {
 		cte.With(idsAlias, filterBd)
 		cte.Join("", idsAlias, entity.IdDbName, cfg.GetTableName(), entity.IdDbName)

--- a/pkg/eta/datin/entity_config.go
+++ b/pkg/eta/datin/entity_config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/davycun/eta/pkg/module/menu"
 	"github.com/davycun/eta/pkg/module/menu/menu_srv"
 	"github.com/davycun/eta/pkg/module/optlog"
-	"github.com/davycun/eta/pkg/module/reload"
 	"github.com/davycun/eta/pkg/module/security"
 	"github.com/davycun/eta/pkg/module/setting"
 	"github.com/davycun/eta/pkg/module/sms"
@@ -206,18 +205,6 @@ func entityConfig() []iface.EntityConfig {
 			Namespace: NS, Name: "eta_task", Migrate: true,
 			ControllerConfig: iface.ControllerConfig{BaseUrl: "/task", DisableMethod: []iface.Method{iface.MethodDeleteByFilters, iface.MethodDelete}},
 			Table:            entity.Table{EntityType: reflect.TypeOf(task.DataTask{})},
-		},
-
-		//Reload模块
-		{
-			Namespace: NS, Name: "eta_reload", Migrate: false,
-			ControllerConfig: iface.ControllerConfig{
-				BaseUrl:    "/reload",
-				DisableApi: true,
-			},
-			ServiceConfig: iface.ServiceConfig{
-				ServiceType: reflect.TypeOf(reload.Service{}),
-			},
 		},
 	}
 }

--- a/pkg/module/integration/service.go
+++ b/pkg/module/integration/service.go
@@ -38,9 +38,6 @@ func transactionCall(c *ctx.Context, param *CommandParam, srvList []txService, r
 		xa.CommitOrRollback(localTxDb, err)
 	}()
 
-	if !param.Order {
-		wg.Add(len(srvList))
-	}
 	for i := range srvList {
 		if param.Order {
 			err = errs.Cover(err, callTxServices(&srvList[i], localTxDb, appTxDb, result))
@@ -48,6 +45,7 @@ func transactionCall(c *ctx.Context, param *CommandParam, srvList []txService, r
 				return err
 			}
 		} else {
+			wg.Add(1)
 			run.Go(func() {
 				defer wg.Done()
 				if err != nil {

--- a/pkg/module/reload/controller.go
+++ b/pkg/module/reload/controller.go
@@ -1,0 +1,43 @@
+package reload
+
+import (
+	"github.com/davycun/eta/pkg/common/ctx"
+	"github.com/davycun/eta/pkg/common/dsync"
+	"github.com/davycun/eta/pkg/core/controller"
+	"github.com/gin-gonic/gin"
+	jsoniter "github.com/json-iterator/go"
+	"io"
+)
+
+func NewReloadController(rdType RdType) gin.HandlerFunc {
+
+	return func(c *gin.Context) {
+		var (
+			param     = &RdParamList{}
+			result    = &RdResultList{}
+			body, err = io.ReadAll(c.Request.Body)
+		)
+
+		//首次json反解析，主要是先获取各实体查询相关的参数，比如entityCode等
+		err = jsoniter.Unmarshal(body, param)
+		if err != nil {
+			controller.ProcessResult(c, result, err)
+			return
+		}
+
+		//绑定实际的实体到对应的参数，主要是先获取entityCode并且设置Data到对应的实体切片
+		for _, item := range param.Items {
+			item.Param.Extra = &dsync.SyncOption{}
+		}
+		//二次json反解析，主要是为了获取重新获取Param.Data具体的对应的实体
+		err = jsoniter.Unmarshal(body, param)
+		if err != nil {
+			controller.ProcessResult(c, result, err)
+			return
+		}
+
+		err = processReload(rdType, ctx.GetContext(c), param, result)
+
+		controller.ProcessResult(c, result, err)
+	}
+}

--- a/pkg/module/reload/dto.go
+++ b/pkg/module/reload/dto.go
@@ -1,0 +1,20 @@
+package reload
+
+import "github.com/davycun/eta/pkg/core/dto"
+
+type RdParamList struct {
+	Concurrent bool      `json:"concurrent,omitempty"` //是否并发执行，默认是顺序执行
+	Items      []RdParam `json:"items" binding:"required"`
+}
+type RdParam struct {
+	TableName string     `json:"table_name" binding:"required"` // EntityConfig.Name, template.code
+	Param     *dto.Param `json:"param" binding:"required"`
+}
+
+type RdResultList struct {
+	Items []RdResult `json:"items" binding:"required"`
+}
+type RdResult struct {
+	TableName string      `json:"table_name"`
+	Result    *dto.Result `json:"result"`
+}

--- a/pkg/module/reload/init.go
+++ b/pkg/module/reload/init.go
@@ -1,20 +1,12 @@
 package reload
 
 import (
-	"github.com/davycun/eta/pkg/common/dsync"
-	"github.com/davycun/eta/pkg/core/controller"
-	"github.com/davycun/eta/pkg/core/dto"
-	"github.com/davycun/eta/pkg/core/iface"
+	"github.com/davycun/eta/pkg/common/global"
 )
 
 func InitModule() {
 
-	controller.Publish("reload", "/db2es", controller.ApiConfig{
-		Handler: func(srv iface.Service, args any, rs any) error {
-			ss := srv.(*Service)
-			return ss.ReloadDb2Es(args.(*dto.Param), rs.(*dto.Result))
-		},
-		GetParam: dto.NewParamWithExtra[dsync.SyncOption](),
-	})
+	group := global.GetGin().Group("/reload")
+	group.POST("/db2es", NewReloadController(RdTypeDb2Es))
 
 }

--- a/pkg/module/reload/registry.go
+++ b/pkg/module/reload/registry.go
@@ -1,0 +1,67 @@
+package reload
+
+import (
+	"github.com/davycun/eta/pkg/core/dto"
+	"github.com/davycun/eta/pkg/core/iface"
+)
+
+var (
+	hooks                           = map[RdType]map[string]Callback{} // rdType -> tableName ->  callback
+	CallbackBefore CallbackPosition = 1
+	CallbackAfter  CallbackPosition = 2
+)
+
+const (
+	RdTypeDb2Es   RdType = "db2es"
+	RdTypeFeature RdType = "feature"
+)
+
+type (
+	RdType           string
+	CallbackPosition int
+	RdService        struct {
+		srv    iface.Service
+		param  *dto.Param
+		result *dto.Result
+	}
+
+	Callback func(cfg *RdService, pos CallbackPosition) error
+)
+
+func (r RdService) GetService() iface.Service {
+	return r.srv
+}
+func (r RdService) GetParam() *dto.Param {
+	return r.param
+}
+func (r RdService) GetResult() *dto.Result {
+	return r.result
+}
+
+func Registry(tableName string, rdType RdType, callback Callback) {
+	mp, ok := hooks[rdType]
+	if !ok {
+		mp = map[string]Callback{}
+	}
+	mp[tableName] = callback
+	hooks[rdType] = mp
+}
+
+func callbackBefore(rdType RdType, rds *RdService) error {
+	_ = operateTrigger(rds.srv, false)
+	if cf, ok := hooks[rdType]; ok {
+		if fc, ok1 := cf[rds.GetService().GetTableName()]; ok1 {
+			return fc(rds, CallbackBefore)
+		}
+	}
+	return nil
+}
+func callbackAfter(rdType RdType, rds *RdService) error {
+	_ = operateTrigger(rds.srv, true)
+	if cf, ok := hooks[rdType]; ok {
+		if fc, ok1 := cf[rds.GetService().GetTableName()]; ok1 {
+			return fc(rds, CallbackAfter)
+		}
+	}
+	return nil
+}

--- a/pkg/module/reload/service.go
+++ b/pkg/module/reload/service.go
@@ -1,9 +1,84 @@
 package reload
 
 import (
+	"errors"
+	"fmt"
+	"github.com/davycun/eta/pkg/common/ctx"
+	"github.com/davycun/eta/pkg/common/dorm"
+	"github.com/davycun/eta/pkg/common/errs"
+	"github.com/davycun/eta/pkg/common/global"
+	"github.com/davycun/eta/pkg/common/run"
+	"github.com/davycun/eta/pkg/core/dto"
 	"github.com/davycun/eta/pkg/core/service"
+	"github.com/davycun/eta/pkg/eta/ecf"
+	"sync"
 )
 
-type Service struct {
-	service.DefaultService
+type (
+	rdFunc func(rds *RdService) error
+)
+
+var (
+	rdFuncMap = map[RdType]rdFunc{
+		RdTypeDb2Es: db2es,
+	}
+)
+
+func processReload(rdType RdType, c *ctx.Context, param *RdParamList, result *RdResultList) error {
+
+	var (
+		appDb   = c.GetAppGorm()
+		localDb = global.GetLocalGorm()
+	)
+
+	rdsList := make([]*RdService, 0, len(param.Items))
+	for _, item := range param.Items {
+		itemCt := c.Clone()
+		ec, ok := ecf.GetEntityConfig(appDb, item.TableName)
+		if !ok {
+			return errors.New("table_name not found")
+		}
+		ecf.SetContextEntityConfig(itemCt, &ec)
+		if ec.LocatedApp() {
+			itemCt.SetContextGorm(appDb)
+		} else {
+			itemCt.SetContextGorm(localDb)
+		}
+		srv, err1 := service.NewService(item.TableName, itemCt, itemCt.GetContextGorm())
+		if err1 != nil {
+			return err1
+		}
+		item.Param.OrderBy = []dorm.OrderBy{{Column: "eid", Asc: true}}
+		rdsList = append(rdsList, &RdService{srv: srv, param: item.Param, result: &dto.Result{}})
+	}
+
+	var (
+		err     error
+		rdf, ok = rdFuncMap[rdType]
+		wg      = sync.WaitGroup{}
+	)
+	if !ok {
+		return errs.NewServerError(fmt.Sprintf("指定的realod func [%s]不存在", rdType))
+	}
+
+	for _, rds := range rdsList {
+		if err != nil {
+			return err
+		}
+		if param.Concurrent {
+			wg.Add(1)
+			run.Go(func() {
+				defer wg.Done()
+				if err != nil {
+					return
+				}
+				err = errs.Cover(err, rdf(rds))
+			})
+		} else {
+			err = rdf(rds)
+		}
+	}
+	wg.Wait()
+
+	return err
 }

--- a/pkg/module/reload/service_common.go
+++ b/pkg/module/reload/service_common.go
@@ -4,211 +4,63 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/davycun/eta/pkg/common/caller"
 	"github.com/davycun/eta/pkg/common/dorm"
-	"github.com/davycun/eta/pkg/common/dorm/es"
 	"github.com/davycun/eta/pkg/common/dorm/filter"
 	"github.com/davycun/eta/pkg/common/dorm/xa"
 	"github.com/davycun/eta/pkg/common/dsync"
 	"github.com/davycun/eta/pkg/common/global"
 	"github.com/davycun/eta/pkg/common/logger"
-	"github.com/davycun/eta/pkg/common/utils"
 	"github.com/davycun/eta/pkg/core/dto"
 	"github.com/davycun/eta/pkg/core/entity"
 	"github.com/davycun/eta/pkg/core/iface"
-	"github.com/davycun/eta/pkg/core/ra"
+	"github.com/davycun/eta/pkg/core/service"
 	"github.com/davycun/eta/pkg/core/service/hook"
 	"github.com/davycun/eta/pkg/eta/constants"
 	"github.com/davycun/eta/pkg/eta/plugin/plugin_es"
 	"reflect"
-	"strings"
-	"time"
-
-	"github.com/duke-git/lancet/v2/slice"
-	"gorm.io/gorm"
-	gormLogger "gorm.io/gorm/logger"
 )
 
-var (
-	silentLogger = gormLogger.New(logger.Logger, gormLogger.Config{LogLevel: gormLogger.Silent})
-	slowLogger   = gormLogger.New(logger.Logger, gormLogger.Config{LogLevel: gormLogger.Warn, SlowThreshold: 30 * time.Second})
-)
-
-func BeforeReload(args *dsync.SyncArgs) error {
-	return caller.NewCaller().
-		Call(func(cl *caller.Caller) error {
-			return operateTrigger(args.Srv, false)
-		}).
-		Call(func(cl *caller.Caller) error {
-			if reLoadSrv, ok := args.Srv.(dsync.ReloadInjector); ok {
-				return reLoadSrv.ReloadBefore(args)
-			}
-			return nil
-		}).Err
-}
-func AfterReload(args *dsync.SyncArgs) error {
-	return caller.NewCaller().
-		Call(func(cl *caller.Caller) error {
-			if reLoadSrv, ok := args.Srv.(dsync.ReloadInjector); ok {
-				return reLoadSrv.ReloadAfter(args)
-			}
-			return nil
-		}).
-		Call(func(cl *caller.Caller) error {
-			return operateTrigger(args.Srv, true)
-		}).Err
-
-}
-
-func QueryLoader(args any) (data any, over bool, err error) {
-	var (
-		sa = args.(*dsync.SyncArgs)
-		//so        = sa.Args.Extra.(*dsync.SyncOption)
-		so        = dto.GetExtra[dsync.SyncOption](sa.Args)
-		srv       = sa.Srv
-		tableName = entity.GetTableName(srv.NewEntityPointer())
-	)
-	buildParam := func(p dto.Param, newId string) dto.Param {
-		fs := []filter.Filter{{
-			LogicalOperator: filter.And,
-			Column:          entity.IdDbName,
-			Operator:        filter.GT,
-			Value:           newId,
-			Filters:         p.Filters,
-		}}
-		p.Filters = fs
-		p.AutoCount = false
-		p.OnlyCount = false
-		p.Columns = []string{}
-		return p
-	}
-	logger.Debugf("query loader %s startId: %s", tableName, so.StartId)
-
-	// 如果有存储加密字段，查询出来的数据需要解密成明文
-	param := buildParam(*sa.Args, so.StartId)
-	result := dto.Result{}
-	err = srv.Query(&param, &result)
-	elem := reflect.ValueOf(result.Data).Elem()
-	if elem.Kind() == reflect.Slice {
-		if elem.Len() <= 0 || elem.Len() < sa.Args.GetLimit() {
-			over = true
-		}
-		if elem.Len() > 0 {
-			so.StartId = elem.Index(elem.Len() - 1).FieldByName(entity.IdFieldName).String()
-		} else {
-			result.Data = nil
-		}
-	}
-	if err != nil {
-		return nil, false, err
-	}
-	return result.Data, over, err
-}
-func EsLoader(args any) (data any, over bool, err error) {
-	var (
-		sa  = args.(*dsync.SyncArgs)
-		so  = dto.GetExtra[dsync.SyncOption](sa.Args)
-		srv = sa.Srv
-		db  = srv.GetDB()
-		ct  = srv.GetContext()
-	)
-
-	buildParam := func(p dto.Param, newId string) dto.Param {
-		fs := []filter.Filter{{
-			LogicalOperator: filter.And,
-			Column:          entity.IdDbName,
-			Operator:        filter.GT,
-			Value:           newId,
-			Filters:         p.Filters,
-		}}
-		p.Filters = fs
-		p.AutoCount = false
-		p.OnlyCount = false
-		p.Columns = []string{}
-		return p
-	}
-	// 如果有存储加密字段，查询出来的数据需要解密成明文
-	param := buildParam(*sa.Args, so.StartId)
-	var (
-		entPtr      = srv.NewEntityPointer()
-		entSlicePtr = srv.NewEntitySlicePointer()
-		tableName   = entity.GetTableName(entPtr)
-	)
-	logger.Debugf("es2db loader %s startId: %s", tableName, so.StartId)
-
-	esApi := es.NewApi(global.GetES(), entity.GetEsIndexNameByDb(db, entPtr),
-		es.CodecOpt(dorm.GetDbSchema(ct.GetAppGorm()), tableName))
-	esApi.AddFilters(ra.KeywordToFilters(ct.GetAppGorm(), tableName, param.SearchContent, dorm.ES)...)
-	esApi.AddFilters(param.Filters...)
-	esApi.OrderBy(param.OrderBy...).Limit(param.GetLimit()).Find(entSlicePtr)
-	err = esApi.Err
-
-	elem := reflect.ValueOf(entSlicePtr).Elem()
-	if elem.Kind() == reflect.Slice {
-		if elem.Len() <= 0 || elem.Len() < sa.Args.GetLimit() {
-			over = true
-		}
-		if elem.Len() > 0 {
-			so.StartId = elem.Index(elem.Len() - 1).FieldByName(entity.IdFieldName).String()
-		} else {
-			entSlicePtr = nil
-		}
-	}
-	if err != nil {
-		return nil, false, err
-	}
-	return entSlicePtr, over, err
-}
 func DbLoader(args any) (data any, over bool, err error) {
 	var (
-		sa     = args.(*dsync.SyncArgs)
-		so     = dto.GetExtra[dsync.SyncOption](sa.Args)
-		srv    = sa.Srv
-		ct     = srv.GetContext()
-		db     = srv.GetDB()
-		dbType = dorm.GetDbType(db)
+		srvArgs = args.(*dsync.SyncArgs)
+		srv     = srvArgs.Srv
+		param   = srvArgs.Args
+		extra   = dto.GetExtra[dsync.SyncOption](param)
 	)
-
-	buildParam := func(p dto.Param, newId string) dto.Param {
-		fs := []filter.Filter{{
+	if !replaceEidFilter(param.Filters, extra.StartEid) && extra.StartEid != 0 {
+		param.Filters = append(param.Filters, filter.Filter{
 			LogicalOperator: filter.And,
-			Column:          entity.IdDbName,
+			Column:          entity.EIdDbName,
 			Operator:        filter.GT,
-			Value:           newId,
-			Filters:         p.Filters,
-		}}
-		p.Filters = fs
-		p.AutoCount = false
-		p.OnlyCount = false
-		p.Columns = []string{}
-		return p
+			Value:           extra.StartEid,
+		})
 	}
-	// 如果有存储加密字段，查询出来的数据需要解密成明文
-	param := buildParam(*sa.Args, so.StartId)
+
 	var (
 		entPtr      = srv.NewEntityPointer()
 		entSlicePtr = srv.NewEntitySlicePointer()
 		tableName   = entity.GetTableName(entPtr)
 	)
-	logger.Debugf("db loader %s startId: %s", tableName, so.StartId)
 
-	tx := dorm.WithContext(db, ct).Model(entSlicePtr)
-	if so.StartId != "" {
-		tx = tx.Where(fmt.Sprintf(`%s > ?`, dorm.Quote(dbType, entity.IdDbName)), so.StartId)
+	logger.Debugf("db loader %s startId: %d", tableName, extra.StartEid)
+
+	listSql, _, err := service.BuildParamSql(srv.GetDB(), param, srv.GetEntityConfig())
+	if err != nil {
+		return nil, true, err
 	}
-	if len(param.Filters) > 0 {
-		tx = tx.Where(filter.ResolveWhere(sa.Args.Filters, dbType))
+
+	err = dorm.RawFetch(listSql, srv.GetDB(), entSlicePtr)
+	if err != nil {
+		return nil, true, err
 	}
-	tx = tx.Order(param.ResolveOrderByString(tableName, "", false))
-	err = tx.Limit(param.GetLimit()).Find(entSlicePtr).Error
 
 	elem := reflect.ValueOf(entSlicePtr).Elem()
 	if elem.Kind() == reflect.Slice {
-		if elem.Len() <= 0 || elem.Len() < sa.Args.GetLimit() {
+		if elem.Len() <= 0 || elem.Len() < param.GetLimit() {
 			over = true
 		}
 		if elem.Len() > 0 {
-			so.StartId = elem.Index(elem.Len() - 1).FieldByName(entity.IdFieldName).String()
+			extra.StartEid = elem.Index(elem.Len() - 1).FieldByName("EID").Int()
 		} else {
 			entSlicePtr = nil
 		}
@@ -217,10 +69,25 @@ func DbLoader(args any) (data any, over bool, err error) {
 		over = true
 		entSlicePtr = nil
 	}
-	if err != nil {
-		return nil, false, err
-	}
 	return entSlicePtr, over, err
+}
+
+func replaceEidFilter(flt []filter.Filter, startEid int64) bool {
+	if startEid == 0 {
+		return false
+	}
+	flag := false
+	for i, _ := range flt {
+		f := &flt[i]
+		if f.Column == "eid" && f.Operator == filter.GT {
+			f.Value = startEid
+			flag = true
+		}
+		if len(f.Filters) > 0 {
+			replaceEidFilter(f.Filters, startEid)
+		}
+	}
+	return flag
 }
 
 func EsSaver(args any, data any) error {
@@ -305,57 +172,4 @@ func checkEsIndex(srv iface.Service) error {
 		return nil
 	}
 	return errors.New(fmt.Sprintf("indics [%s] does not exist,", indexName))
-}
-
-// 更新数据库
-func dbUpdateFeature(args *dsync.SyncArgs, data any) error {
-	if utils.IsEmptySlice(data) {
-		return nil
-	}
-	var (
-		so   = args.Args.Extra.(*dsync.SyncOption)
-		srv  = args.Srv
-		cols = make([]string, 0)
-		//tb           = data.GetContextTable(srv.GetContext())
-		ec           = iface.GetContextEntityConfig(srv.GetContext())
-		tb           = ec.GetTable()
-		tableName    = entity.GetTableName(srv.NewEntityPointer())
-		isHistoryTbl = strings.HasSuffix(tableName, constants.TableHistorySubFix)
-	)
-	if so.UpdateDbRaContent {
-		cols = append(cols, entity.RaContentDbName)
-	}
-	if so.UpdateDbEncrypt {
-		for _, v := range tb.CryptFields {
-			cols = utils.Merge(cols, v.Field)
-		}
-	}
-	if so.UpdateDbSign {
-		for _, v := range tb.SignFields {
-			cols = utils.Merge(cols, v.Field)
-		}
-	}
-	if isHistoryTbl {
-		cols = slice.Map(cols, func(_ int, item string) string { return fmt.Sprintf("h_%s", item) })
-	}
-
-	// data 切片
-	val := reflect.ValueOf(data)
-	if val.Kind() == reflect.Pointer {
-		val = val.Elem()
-	}
-	if val.Kind() == reflect.Slice && val.Len() > 0 {
-		dataChunks, _ := utils.Chunk(data, so.GetUpdateDbBatchSize())
-		for _, dataChunk := range dataChunks {
-			tx := srv.GetDB().Session(&gorm.Session{NewDB: true, Logger: slowLogger})
-			err := dorm.BatchUpdate(tx, dataChunk, entity.IdDbName, cols...)
-			if err != nil {
-				return err
-			}
-		}
-		sl, _ := utils.SliceLen(data)
-		logger.Debugf("写入DB %d 条数据完成", sl)
-		return nil
-	}
-	return nil
 }

--- a/pkg/module/reload/service_db2es.go
+++ b/pkg/module/reload/service_db2es.go
@@ -2,70 +2,38 @@ package reload
 
 import (
 	"github.com/davycun/eta/pkg/common/caller"
-	"github.com/davycun/eta/pkg/common/dorm"
 	"github.com/davycun/eta/pkg/common/dsync"
 	"github.com/davycun/eta/pkg/common/logger"
-	"github.com/davycun/eta/pkg/core/dto"
-	"github.com/davycun/eta/pkg/core/entity"
-	"github.com/davycun/eta/pkg/core/iface"
-	"github.com/davycun/eta/pkg/core/service"
 )
 
-func (s *Service) ReloadDb2Es(args *dto.Param, rs *dto.Result) error {
-	dto.InitPage(args)
+func db2es(rds *RdService) error {
 
-	entityCodeList := args.Columns
-	args.Columns = []string{}
-	if len(entityCodeList) <= 0 {
-		return nil
+	logger.Infof("%s 的 db2es reload 操作开始...", rds.GetService().GetTableName())
+	// 每个表都需要重新构建一下参数。这里的参数，
+	//args.Extra = &so
+	buildNewSyncOption(rds.GetService(), rds.GetParam())
+
+	srvArgs := &dsync.SyncArgs{Args: rds.GetParam(), Srv: rds.GetService()}
+	err := caller.NewCaller().
+		Call(func(cl *caller.Caller) error {
+			return checkEsIndex(rds.GetService())
+		}).
+		Call(func(cl *caller.Caller) error {
+			return callbackBefore(RdTypeDb2Es, rds)
+		}).
+		Call(func(cl *caller.Caller) error {
+			option := GetSyncOption(rds.GetService(), rds.GetParam())
+			syncSrv := dsync.NewAntsSyncService(DbLoader, EsSaver, *option)
+			return syncSrv.Sync(srvArgs, srvArgs)
+		}).
+		Call(func(cl *caller.Caller) error {
+			return callbackAfter(RdTypeDb2Es, rds)
+		}).Err
+
+	if err != nil {
+		logger.Errorf("reload db2es Sync 失败. %s", err.Error())
+	} else {
+		logger.Infof("%s 的 db2es reload 操作完成!!!", rds.GetService().GetTableName())
 	}
-
-	//srvList, err := service_loader.LoadSrvList(s.GetContext(), true, entityCodeList...)
-
-	srvList := make([]iface.Service, 0, len(entityCodeList))
-	for _, v := range entityCodeList {
-		sr, err1 := service.NewService(v, s.GetContext().Clone(), s.GetDB())
-		if err1 != nil {
-			return err1
-		}
-		srvList = append(srvList, sr)
-	}
-
-	args.OrderBy = []dorm.OrderBy{{Column: entity.IdDbName, Asc: true}}
-	so := *(args.Extra.(*dsync.SyncOption))
-
-	for _, srv := range srvList {
-		logger.Infof("%s 的 db2es reload 操作开始...", srv.GetTableName())
-		// 每个表都需要重新构建一下参数。这里的参数，
-		args.Extra = &so
-		buildNewSyncOption(srv, args)
-
-		sa := &dsync.SyncArgs{Args: args, Srv: srv}
-		err := caller.NewCaller().
-			Call(func(cl *caller.Caller) error {
-				return checkEsIndex(srv)
-			}).
-			Call(func(cl *caller.Caller) error {
-				return BeforeReload(sa)
-			}).
-			Call(func(cl *caller.Caller) error {
-				option := GetSyncOption(srv, args)
-				syncSrv := dsync.NewAntsSyncService(DbLoader, EsSaver, *option)
-				return syncSrv.Sync(sa, sa)
-			}).Err
-
-		if err != nil {
-			logger.Errorf("reload db2es Sync 失败. %s", err.Error())
-			return err
-		}
-
-		err = AfterReload(sa)
-		if err != nil {
-			logger.Errorf("reload db2es AfterReload 失败. %s", err.Error())
-			return err
-		}
-
-		logger.Infof("%s 的 db2es reload 操作完成!!!", srv.GetTableName())
-	}
-	return nil
+	return err
 }


### PR DESCRIPTION
[调整针对Json类型，ES不自动进行字段扩展]
[所有实体统一新增一个eid字段，数据库自增，此字段只在当前表唯一，不是全局唯一，为了提升当前表id排序性能]
[修复集成并发执行的问题](https://github.com/davycun/eta/commit/acfe082e92211dd985e75762aa7268a7fefd1a5c)
[cache新增一个LoadByFilters函数，可以直接数据库查询不经过缓存，当然查询后的数据也会缓存在内存中]
[调整GetGormFieldName函数名为GetTableColumns，同时支持exclude字段]
[service包下把通过dto.Param构建sql的内部函数进行暴露供外部使用]


resolves #54 
